### PR TITLE
Simplify passed messages

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -13,13 +13,13 @@ jobs:
         with:
           python-version: 3.7
       - name: Install dependencies
-        run: python -m pip install --upgrade black
+        run: python -m pip install --upgrade black==20.8b1
       - name: Check with Black
         run: |
           echo $PWD
           black --version
-          black . --check --exclude get-poetry.py
           black . --diff --exclude get-poetry.py
+          black . --check --exclude get-poetry.py
 
   Test:
     needs: Linting

--- a/netprocess/__init__.py
+++ b/netprocess/__init__.py
@@ -1,1 +1,1 @@
-from . import network_process, jax_utils, networks, utils
+from . import jax_utils, networks, utils, network_process, epi

--- a/netprocess/epi/__init__.py
+++ b/netprocess/epi/__init__.py
@@ -1,1 +1,1 @@
-from .seir import SIRUpdateOperation
+from .seir import SIRUpdateOp

--- a/netprocess/epi/seir.py
+++ b/netprocess/epi/seir.py
@@ -2,49 +2,58 @@ import jax
 import jax.numpy as jnp
 
 from ..jax_utils import cond, switch
-from ..network_process import OperationBase
+from ..network_process import OperationBase, ProcessStateData
+from ..utils import PRNGKey, PytreeDict
 
 
-class SIRUpdateOperation(OperationBase):
-    def __init__(self, state_key="compartment", prefix=""):
-        self.prefix = prefix
-        self.state_key = state_key
+class SIRUpdateOp(OperationBase):
+    def __init__(
+        self,
+        state_key="compartment",
+        infected_key="infected",
+        infection_key="_infection",
+    ):
+        self.STATE = state_key
+        self.INFECTED = infected_key
+        self.INFECTION = infection_key
 
     def prepare_state_pytrees(self, state):
-        state.nodes_pytree.setdefault(
-            "compartment", jnp.zeros(state.n, dtype=jnp.int32)
-        )
-        state.nodes_pytree.setdefault("infected", jnp.zeros(state.n, dtype=jnp.int32))
+        state.nodes_pytree.setdefault(self.STATE, jnp.zeros(state.n, dtype=jnp.int32))
+        if not self.INFECTED.startswith("_"):
+            state.nodes_pytree.setdefault(
+                self.INFECTED, jnp.zeros(state.n, dtype=jnp.int32)
+            )
         state.params_pytree.setdefault("edge_beta", 0.05)
         state.params_pytree.setdefault("gamma", 0.1)
 
     def update_edge(self, rng_key, params, edge, from_node, to_node):
         infection = cond(
-            jnp.logical_and(from_node["compartment"] == 1, to_node["compartment"] == 0),
+            jnp.logical_and(from_node[self.STATE] == 1, to_node[self.STATE] == 0),
             lambda: jnp.int32(jax.random.bernoulli(rng_key, params["edge_beta"])),
             0,
         )
-        return {}, {"infection": infection}, {"infection": infection}
+        return {self.INFECTION: infection}
 
     def update_node(self, rng_key, params, node, in_edges, out_edges):
         compartment = switch(
             [
                 # S -> {S, I}:
-                lambda: cond(in_edges["sum"]["infection"] > 0, 1, 0),
+                lambda: cond(in_edges["sum"][self.INFECTION] > 0, 1, 0),
                 # I -> {I, R}:
                 lambda: cond(jax.random.bernoulli(rng_key, params["gamma"]), 2, 1),
                 # R -> {R}:
                 2,
             ],
-            node["compartment"],
+            node[self.STATE],
         )
         return {
-            "compartment": compartment,
-            "infected": node["infected"] + out_edges["sum"]["infection"],
+            self.STATE: compartment,
+            self.INFECTED: node[self.INFECTED] + out_edges["sum"][self.INFECTION],
         }
 
 
-class ComputeImmediateROperation:
-    def update_params_and_record(self, rng_key, state, new_nodes, new_edges):
-        # TODO
+class ComputeImmediateROp:
+    def create_record(
+        self, rng_key: PRNGKey, state: ProcessStateData, orig_state: ProcessStateData
+    ) -> PytreeDict:
         return {}, {"immediate_R_mean": mean, "immediate_R_samples": count}

--- a/netprocess/network_process/common_ops.py
+++ b/netprocess/network_process/common_ops.py
@@ -1,0 +1,44 @@
+import jax
+import jax.numpy as jnp
+
+from ..utils import PRNGKey, PytreeDict
+from .state import ProcessStateData
+
+
+class CountNodeStatesOp:
+    def __init__(self, states: int, key: str = "state", dest: str = None):
+        self.states = states
+        self.key = key
+        self.dest = dest if dest is not None else f"{self.key}_count"
+
+    def create_record(
+        self,
+        rng_key: PRNGKey,
+        state: ProcessStateData,
+        orig_state: ProcessStateData,
+    ) -> PytreeDict:
+        counts = jnp.sum(
+            jax.nn.one_hot(state.nodes_pytree[self.key], self.states), axis=0
+        )
+        return {}, {self.dest: counts}
+
+
+class CountNodeTransitionsOp:
+    def __init__(self, states: int, key: str = "state", dest: str = None):
+        self.states = states
+        self.key = key
+        self.dest = dest if dest is not None else f"{self.key}_transitions"
+
+    def create_record(
+        self,
+        rng_key: PRNGKey,
+        state: ProcessStateData,
+        orig_state: ProcessStateData,
+    ) -> PytreeDict:
+        transitions = (
+            self.states * state.nodes_pytree[self.key]
+            + orig_state.nodes_pytree[self.key]
+        )
+        counts = jnp.sum(jax.nn.one_hot(transitions, self.states * self.states), axis=0)
+        counts_from_to = jnp.reshape(counts, (self.states, self.states))
+        return {self.dest: counts_from_to}

--- a/netprocess/network_process/operation.py
+++ b/netprocess/network_process/operation.py
@@ -23,20 +23,20 @@ class OperationBase:
         edge: PytreeDict,
         from_node: PytreeDict,
         to_node: PytreeDict,
-    ) -> (PytreeDict, PytreeDict, PytreeDict):
+    ) -> PytreeDict:
         """
-        Compute and return the edge update keys and messages to from_node and to_node.
+        Compute and return the edge updates and messages to from_node and to_node.
 
-        Return `(edge_update_dict, from_update_dict, to_update_dict)`.
-        Must always return the same key sets!
-        Underscore prefixed items are not kept in state and only passed to create_record
-        and used for debugging.
+        Returns a single pytree dict. Underscored items are temporary, non-nderscored
+        items are edge updates. All items are seen by all the later update functions
+        in the same step, underscored items are not persistet to next step.
+        Must always return the same key sets! Must be JITtable.
 
         `params`, `edge`, `from_node` and `to_node` are all dict pytrees.
 
         Must be JIT-able.
         """
-        return {}, {}, {}
+        return {}
 
     def update_node(
         self,
@@ -49,9 +49,9 @@ class OperationBase:
         """
         Compute and return the node update items.
 
-        Must always return the same key set!
-        Underscore prefixed items are not kept in state and only passed to create_record
-        and used for debugging.
+        Must always return the same key set! Must be JITtable.
+        All items are seen by all the later update functions
+        in the same step, underscored items are not persistet to next step.
 
         `params` and `node` are dict pytrees. `in_edges` and `out_edges` are nested
         aggregates of update_edge pytrees. Currently, "sum", "prod", "min", and "max"
@@ -62,18 +62,35 @@ class OperationBase:
         """
         return {}
 
-    def update_params_and_record(
+    def update_params(
         self,
         rng_key: PRNGKey,
-        old_state: ProcessStateData,
-        updated_nodes: PytreeDict,
-        updated_edges: PytreeDict,
-    ) -> (PytreeDict, PytreeDict):
+        state: ProcessStateData,
+        orig_state: ProcessStateData,
+    ) -> PytreeDict:
+        """
+        Compute and return the param updates.
+
+        Return a pytree dictionary.
+        Must always return the same key sets. Must be JIT-able.
+        `state` includes temporary (underscored) properties.
+        """
+        return {}
+
+    def create_record(
+        self,
+        rng_key: PRNGKey,
+        state: ProcessStateData,
+        orig_state: ProcessStateData,
+    ) -> PytreeDict:
+        return {}
         """
         Compute and return the param updates and any records.
 
-        Return `(param_updates_pytree, record_pytree)`.
+        Return `record_pytree`.
         Must always return the same key sets. Must be JIT-able.
-        `updated_nodes' and `updated_edges` include teporary underscored items.
+        `state` includes temporary (underscored) properties.
         """
-        return {}, {}
+
+    def __repr__(self):
+        return f"<{self.__class__.__name__}>"

--- a/netprocess/network_process/operation.py
+++ b/netprocess/network_process/operation.py
@@ -63,10 +63,7 @@ class OperationBase:
         return {}
 
     def update_params(
-        self,
-        rng_key: PRNGKey,
-        state: ProcessStateData,
-        orig_state: ProcessStateData,
+        self, rng_key: PRNGKey, state: ProcessStateData, orig_state: ProcessStateData
     ) -> PytreeDict:
         """
         Compute and return the param updates.
@@ -78,10 +75,7 @@ class OperationBase:
         return {}
 
     def create_record(
-        self,
-        rng_key: PRNGKey,
-        state: ProcessStateData,
-        orig_state: ProcessStateData,
+        self, rng_key: PRNGKey, state: ProcessStateData, orig_state: ProcessStateData
     ) -> PytreeDict:
         return {}
         """

--- a/netprocess/network_process/process.py
+++ b/netprocess/network_process/process.py
@@ -20,7 +20,9 @@ class NetworkProcess:
 
         self.operations = tuple(operations)
         assert all(isinstance(op, OperationBase) for op in self.operations)
-        self._run_jit = jax.jit(self._run)
+        self._run_jit = jax.jit(self._run, static_argnums=[2])
+        self._traced = 0
+        self._trace_log = []
 
     def __repr__(self):
         return f"<{self.__class__.__name__} {self.operations}>"
@@ -29,10 +31,15 @@ class NetworkProcess:
         steps_array = jnp.zeros((steps, 1))
         state_data = state.as_pytree()
         if jit:
-            state_update, records = self._run_jit(state_data, steps_array)
+            state_update, records = self._run_jit(state_data, steps_array, True)
         else:
-            state_update, records = self._run(state_data, steps_array)
+            state_update, records = self._run(state_data, steps_array, False)
         return state.copy_updated(state_update, [records])
+
+    def trace_log(self):
+        return f"Traced {self._traced} times, last log:\n" + (
+            "\n".join(self._trace_log)
+        )
 
     def warmup_jit(self, state=None, n=None, m=None, block=True):
         """Force the compilation of the JITted run function and wait for it (if `block`)."""
@@ -47,16 +54,25 @@ class NetworkProcess:
         if block:
             new_state.block_on_all()
 
-    def _run(self, state: ProcessStateData, steps_array: jnp.int32):
+    def _run(self, state: ProcessStateData, steps_array: jnp.int32, tracing: bool):
         """Returns (new_state, all_records_pytree). JIT-able."""
-        return jax.lax.scan(lambda s, _: self._run_step(s), state, steps_array)
+        if tracing:
+            self._traced += 1
+            self._trace_log = []
+        log.debug(
+            f"Tracing {self} with n={state.n}, m={state.m}, steps={len(steps_array)}"
+        )
+        return jax.lax.scan(
+            lambda s, _: self._run_step(s, tracing=tracing), state, steps_array
+        )
 
-    def _run_step(self, state: ProcessStateData):
+    def _run_step(self, state: ProcessStateData, tracing=False):
         """Returns (new_state, record_pytree). JIT-able."""
 
         # Randomness - split into new key, forget the old one
         step_rng_key, new_rng_key = jax.random.split(state.rng_key)
         state = state._replace(rng_key=None)
+        orig_state = state
 
         # Step 1: Extract node values for edge endpoints
         n2e_from_pytree = jax.tree_util.tree_map(
@@ -65,29 +81,41 @@ class NetworkProcess:
         n2e_to_pytree = jax.tree_util.tree_map(
             lambda a: a[state.edges[:, 1]], state.nodes_pytree
         )
-        # n2e_to_dict = {k: nodes_dict[k][e_to] for k in nodes_dict}
+
+        if tracing:
+            self._trace_log.append(
+                f"Param keys: {', '.join(state.params_pytree.keys())}"
+            )
+            self._trace_log.append(
+                f"Node keys:  {', '.join(state.nodes_pytree.keys())}"
+            )
+            self._trace_log.append(
+                f"Edge keys:  {', '.join(state.edges_pytree.keys())}"
+            )
 
         # Step 2: Compute edge operations and messages
         def edge_f(shared_rng_key, params, e_pt, from_pt, to_pt):
             "Apply all operations on each edge"
-            e_up, from_up, to_up = {}, {}, {}
+            e_pt = e_pt.copy()
             rng_key = jax.random.fold_in(shared_rng_key, e_pt["i"])
             for i, op in enumerate(self.operations):
                 r = jax.random.fold_in(rng_key, i)
                 updates = op.update_edge(r, params, e_pt, from_pt, to_pt)
-                for tgt, up in zip([e_up, from_up, to_up], updates):
-                    utils.update_dict_disjoint(tgt, up)
-            return e_up, from_up, to_up
+                if updates and tracing:
+                    self._trace_log.append(f"  {op} -> {', '.join(updates.keys())}")
+                e_pt.update(updates)
+            return e_pt
 
-        edge_update_pytree, e2n_from_pytree, e2n_to_pytree = jax.vmap(
-            edge_f, in_axes=(None, None, 0, 0, 0)
-        )(
+        if tracing:
+            self._trace_log.append("Edge updates:")
+        new_edges_pytree = jax.vmap(edge_f, in_axes=(None, None, 0, 0, 0))(
             jax.random.fold_in(step_rng_key, 0),
             state.params_pytree,
             state.edges_pytree,
             n2e_from_pytree,
             n2e_to_pytree,
         )
+        state = state._replace(edges_pytree=new_edges_pytree)
 
         # Step 3: Compute edge-to-node value aggregates
         def scatter_op(agg_op, agg_base, e_vals, e_endpoints):
@@ -113,7 +141,7 @@ class NetworkProcess:
         ):
             in_edges_agg[agg_name] = jax.tree_util.tree_map(
                 lambda a: scatter_op(agg_op, agg_base, a, state.edges[:, 1]),
-                e2n_to_pytree,
+                new_edges_pytree,
             )
             out_edges_agg[agg_name] = jax.tree_util.tree_map(
                 lambda a: scatter_op(
@@ -122,55 +150,77 @@ class NetworkProcess:
                     a,
                     state.edges[:, 0],
                 ),
-                e2n_from_pytree,
+                new_edges_pytree,
             )
 
         # Step 4: Compute node operations and updates
         def node_f(shared_rng_key, params, n_pt, in_edges_agg, out_edges_agg):
             "Apply all operations on each node"
-            n_up = {}
+            n_pt = n_pt.copy()
             rng_key = jax.random.fold_in(shared_rng_key, n_pt["i"])
             for i, op in enumerate(self.operations):
                 r = jax.random.fold_in(rng_key, i)
-                update = op.update_node(r, params, n_pt, in_edges_agg, out_edges_agg)
-                utils.update_dict_disjoint(n_up, update)
-            return n_up
+                updates = op.update_node(r, params, n_pt, in_edges_agg, out_edges_agg)
+                if updates and tracing:
+                    self._trace_log.append(f"  {op} -> {', '.join(updates.keys())}")
+                n_pt.update(updates)
+            return n_pt
 
-        node_update_pytree = jax.vmap(node_f, in_axes=(None, None, 0, 0, 0))(
+        if tracing:
+            self._trace_log.append("Node updates:")
+        new_nodes_pytree = jax.vmap(node_f, in_axes=(None, None, 0, 0, 0))(
             jax.random.fold_in(step_rng_key, 1),
             state.params_pytree,
             state.nodes_pytree,
             in_edges_agg,
             out_edges_agg,
         )
+        state = state._replace(nodes_pytree=new_nodes_pytree)
 
-        # Step 5: Compute param updates and records
-        param_update_pytree, records = {}, {}
+        # Step 5: Compute param updates
+        if tracing:
+            self._trace_log.append("Param updates:")
+        new_params_pytree = state.params_pytree.copy()
         for op in self.operations:
-            updates = op.update_params_and_record(
+            updates = op.update_params(
                 jax.random.fold_in(step_rng_key, 2),
                 state,
-                node_update_pytree,
-                edge_update_pytree,
+                orig_state,
             )
-            utils.update_dict_disjoint(param_update_pytree, updates[0])
-            utils.update_dict_disjoint(records, updates[1])
+            if updates and tracing:
+                self._trace_log.append(f"  {op} -> {', '.join(updates.keys())}")
+            new_params_pytree.update(updates)
+        state = state._replace(params_pytree=new_params_pytree)
+
+        # Step 6: Create any records
+        if tracing:
+            self._trace_log.append("Creating records:")
+        records = {}
+        for op in self.operations:
+            updates = op.create_record(
+                jax.random.fold_in(step_rng_key, 2),
+                state,
+                orig_state,
+            )
+            if updates and tracing:
+                self._trace_log.append(f"  {op} -> {', '.join(updates.keys())}")
+            records.update(updates)
 
         # Create the new state, filtering underlines and checking
         # that we only update existing keys
-        new_state = state._replace(
+        state = state._replace(
             rng_key=new_rng_key,
             params_pytree=_filter_check_merge(
-                state.params_pytree, param_update_pytree, "params"
+                orig_state.params_pytree, state.params_pytree, "params"
             ),
             nodes_pytree=_filter_check_merge(
-                state.nodes_pytree, node_update_pytree, "node"
+                orig_state.nodes_pytree, state.nodes_pytree, "node"
             ),
             edges_pytree=_filter_check_merge(
-                state.edges_pytree, edge_update_pytree, "edge"
+                orig_state.edges_pytree, state.edges_pytree, "edge"
             ),
         )
-        return new_state, [records]
+        return state, [records]
 
     def new_state(
         self,

--- a/netprocess/scripts/bench.py
+++ b/netprocess/scripts/bench.py
@@ -20,7 +20,7 @@ log = logging.getLogger(__name__)
 @click.option("-g", "--gamma", default=0.07)
 def bench_sir(edge_beta, gamma):
 
-    np = network_process.NetworkProcess([epi.SIRUpdateOperation()])
+    np = network_process.NetworkProcess([epi.SIRUpdateOp()])
     params = {"edge_beta": edge_beta, "gamma": gamma}
 
     for n in [100, 10000, 1000000]:

--- a/netprocess/utils.py
+++ b/netprocess/utils.py
@@ -4,6 +4,7 @@ import time
 import typing
 
 import jax.numpy as jnp
+import jax
 
 Pytree = typing.Any
 PytreeDict = typing.Dict[str, typing.Any]
@@ -46,3 +47,30 @@ def logged_time(name, level=logging.INFO):
     yield
     t1 = time.time()
     log.log(level, f"{name} took {t1-t0:.3g} s")
+
+
+class TracingDict(dict):
+    """
+    Utility dict wrapper to track accessed keys.
+
+    Iteration is ignored.
+    """
+
+    def __init__(self, d: dict, target: set, prefix: str = "", suffix: str = ""):
+        super().__init__(d)
+        self._target = target
+        self._prefix = prefix
+        self._suffix = suffix
+
+    def _as_dict(self):
+        return dict(self.items())
+
+    def __getitem__(self, key):
+        r = super().__getitem__(key)
+        self._target.add(f"{self._prefix}{key!s}{self._suffix}")
+        return r
+
+
+# jax.tree_util.register_pytree_node(
+#    TracingDict, lambda td: ((td._as_dict(),), None), lambda _, d: d[0]
+# )

--- a/poetry.lock
+++ b/poetry.lock
@@ -41,12 +41,13 @@ description = "Classes Without Boilerplate"
 name = "attrs"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "20.1.0"
+version = "20.2.0"
 
 [package.extras]
 dev = ["coverage (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface", "sphinx", "sphinx-rtd-theme", "pre-commit"]
 docs = ["sphinx", "sphinx-rtd-theme", "zope.interface"]
 tests = ["coverage (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface"]
+tests_no_zope = ["coverage (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six"]
 
 [[package]]
 category = "dev"
@@ -174,7 +175,7 @@ description = "File identification library for Python"
 name = "identify"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
-version = "1.4.29"
+version = "1.5.3"
 
 [package.extras]
 license = ["editdistance"]
@@ -258,7 +259,7 @@ description = "Differentiate, compile, and transform Numpy code."
 name = "jax"
 optional = false
 python-versions = ">=3.6"
-version = "0.1.75"
+version = "0.1.77"
 
 [package.dependencies]
 absl-py = "*"
@@ -271,7 +272,7 @@ description = "XLA library for JAX"
 name = "jaxlib"
 optional = false
 python-versions = ">=3.6"
-version = "0.1.52"
+version = "0.1.55"
 
 [package.dependencies]
 absl-py = "*"
@@ -355,7 +356,7 @@ description = "NumPy is the fundamental package for array computing with Python.
 name = "numpy"
 optional = false
 python-versions = ">=3.6"
-version = "1.19.1"
+version = "1.19.2"
 
 [[package]]
 category = "main"
@@ -390,7 +391,7 @@ description = "Powerful data structures for data analysis, time series, and stat
 name = "pandas"
 optional = false
 python-versions = ">=3.6.1"
-version = "1.1.1"
+version = "1.1.2"
 
 [package.dependencies]
 numpy = ">=1.15.4"
@@ -445,7 +446,7 @@ description = "An open-source, interactive data visualization library for Python
 name = "plotly"
 optional = false
 python-versions = "*"
-version = "4.9.0"
+version = "4.10.0"
 
 [package.dependencies]
 retrying = ">=1.3.3"
@@ -541,7 +542,7 @@ description = "Pygments is a syntax highlighting package written in Python."
 name = "pygments"
 optional = false
 python-versions = ">=3.5"
-version = "2.6.1"
+version = "2.7.1"
 
 [[package]]
 category = "dev"
@@ -656,7 +657,7 @@ description = "Fast, Extensible Progress Meter"
 name = "tqdm"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*"
-version = "4.48.2"
+version = "4.49.0"
 
 [package.extras]
 dev = ["py-make (>=0.1.0)", "twine", "argopt", "pydoc-markdown"]
@@ -749,7 +750,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "e0188f5628419a69d44182351e4a2de088fc19a3ea064c3b0451ed25456f622c"
+content-hash = "64e22285656a077ef52800f6c0e2147bff5ba254853d3ce0a3815c5987c6eee4"
 lock-version = "1.0"
 python-versions = "^3.6.9"
 
@@ -771,8 +772,8 @@ atomicwrites = [
     {file = "atomicwrites-1.4.0.tar.gz", hash = "sha256:ae70396ad1a434f9c7046fd2dd196fc04b12f9e91ffb859164193be8b6168a7a"},
 ]
 attrs = [
-    {file = "attrs-20.1.0-py2.py3-none-any.whl", hash = "sha256:2867b7b9f8326499ab5b0e2d12801fa5c98842d2cbd22b35112ae04bf85b4dff"},
-    {file = "attrs-20.1.0.tar.gz", hash = "sha256:0ef97238856430dcf9228e07f316aefc17e8939fc8507e18c6501b761ef1a42a"},
+    {file = "attrs-20.2.0-py2.py3-none-any.whl", hash = "sha256:fce7fc47dfc976152e82d53ff92fa0407700c21acd20886a13777a0d20e655dc"},
+    {file = "attrs-20.2.0.tar.gz", hash = "sha256:26b54ddbbb9ee1d34d5d3668dd37d6cf74990ab23c828c2888dccdceee395594"},
 ]
 backcall = [
     {file = "backcall-0.2.0-py2.py3-none-any.whl", hash = "sha256:fbbce6a29f263178a1f7915c1940bde0ec2b2a967566fe1c65c1dfb7422bd255"},
@@ -819,8 +820,8 @@ flake8 = [
     {file = "flake8-3.8.3.tar.gz", hash = "sha256:f04b9fcbac03b0a3e58c0ab3a0ecc462e023a9faf046d57794184028123aa208"},
 ]
 identify = [
-    {file = "identify-1.4.29-py2.py3-none-any.whl", hash = "sha256:b1aa2e05863dc80242610d46a7b49105e2eafe00ef0c8ff311c1828680760c76"},
-    {file = "identify-1.4.29.tar.gz", hash = "sha256:9f5fcf22b665eaece583bd395b103c2769772a0f646ffabb5b1f155901b07de2"},
+    {file = "identify-1.5.3-py2.py3-none-any.whl", hash = "sha256:d02d004568c5a01261839a05e91705e3e9f5c57a3551648f9b3fb2b9c62c0f62"},
+    {file = "identify-1.5.3.tar.gz", hash = "sha256:c770074ae1f19e08aadbda1c886bc6d0cb55ffdc503a8c0fe8699af2fc9664ae"},
 ]
 importlib-metadata = [
     {file = "importlib_metadata-1.7.0-py2.py3-none-any.whl", hash = "sha256:dc15b2969b4ce36305c51eebe62d418ac7791e9a157911d58bfb1f9ccd8e2070"},
@@ -839,15 +840,15 @@ ipython-genutils = [
     {file = "ipython_genutils-0.2.0.tar.gz", hash = "sha256:eb2e116e75ecef9d4d228fdc66af54269afa26ab4463042e33785b887c628ba8"},
 ]
 jax = [
-    {file = "jax-0.1.75.tar.gz", hash = "sha256:140b0b7ff9e7483c3efae54fa3dd2cc86559536482ea15d2b2cad6001780c85e"},
+    {file = "jax-0.1.77.tar.gz", hash = "sha256:63188ea819f3579b054952fbaa2b71e76823f1b60bccea64c95b5609edbdff83"},
 ]
 jaxlib = [
-    {file = "jaxlib-0.1.52-cp36-none-macosx_10_9_x86_64.whl", hash = "sha256:7f089df0a9cd76164a125e6fc6660f32c9708fedd2dc80d1ac9816a0d0ef2526"},
-    {file = "jaxlib-0.1.52-cp36-none-manylinux2010_x86_64.whl", hash = "sha256:b98b96e2b583796df94e20d9f3f56b1f86523a31c6388abc8d5e351d35bc4e9c"},
-    {file = "jaxlib-0.1.52-cp37-none-macosx_10_9_x86_64.whl", hash = "sha256:0752a8980ac2b1b320b3c025aabd62c81da0f89eafcd5b3cde32349e963c76d6"},
-    {file = "jaxlib-0.1.52-cp37-none-manylinux2010_x86_64.whl", hash = "sha256:03e698911477dee615af88a339288e3cd970678b20adfdb3d5d07f80282d87af"},
-    {file = "jaxlib-0.1.52-cp38-none-macosx_10_9_x86_64.whl", hash = "sha256:000aa3b3b2b7e6d7ec292fa65ea87bc7a3dfda156a105100c4be8730ed069aaf"},
-    {file = "jaxlib-0.1.52-cp38-none-manylinux2010_x86_64.whl", hash = "sha256:0d29164227c260cf26896ad433f95b12bd47c5102dd341345cc11fad1b436f2e"},
+    {file = "jaxlib-0.1.55-cp36-none-macosx_10_9_x86_64.whl", hash = "sha256:725bf7912fd2789fd5b89fd0caa96fbf1504bdc144e7e3ce799bdb19bd2afdbb"},
+    {file = "jaxlib-0.1.55-cp36-none-manylinux2010_x86_64.whl", hash = "sha256:f572f78501e95c6210af44a80289f30a53200e80f200cab625b2b065493750a3"},
+    {file = "jaxlib-0.1.55-cp37-none-macosx_10_9_x86_64.whl", hash = "sha256:75382b616f47a825f60969bf3594750ce22dbb9b98ac064bed938977a7c0f217"},
+    {file = "jaxlib-0.1.55-cp37-none-manylinux2010_x86_64.whl", hash = "sha256:0aefe4dfed5c4a1d9482d845780567a53c555e6e7ad618ec87999e36e28d390f"},
+    {file = "jaxlib-0.1.55-cp38-none-macosx_10_9_x86_64.whl", hash = "sha256:319fe83080be379477bda491d04d44b19099531d0a914916c2359e0d5806f845"},
+    {file = "jaxlib-0.1.55-cp38-none-manylinux2010_x86_64.whl", hash = "sha256:2fb35969be8cba8aa4772ba682006ab3452b481d771ed4e9257bd78d4046f7fa"},
 ]
 jedi = [
     {file = "jedi-0.17.2-py2.py3-none-any.whl", hash = "sha256:98cc583fa0f2f8304968199b01b6b4b94f469a1f4a74c1560506ca2a211378b5"},
@@ -874,32 +875,32 @@ nodeenv = [
     {file = "nodeenv-1.5.0.tar.gz", hash = "sha256:ab45090ae383b716c4ef89e690c41ff8c2b257b85b309f01f3654df3d084bd7c"},
 ]
 numpy = [
-    {file = "numpy-1.19.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:b1cca51512299841bf69add3b75361779962f9cee7d9ee3bb446d5982e925b69"},
-    {file = "numpy-1.19.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:c9591886fc9cbe5532d5df85cb8e0cc3b44ba8ce4367bd4cf1b93dc19713da72"},
-    {file = "numpy-1.19.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:cf1347450c0b7644ea142712619533553f02ef23f92f781312f6a3553d031fc7"},
-    {file = "numpy-1.19.1-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:ed8a311493cf5480a2ebc597d1e177231984c818a86875126cfd004241a73c3e"},
-    {file = "numpy-1.19.1-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:3673c8b2b29077f1b7b3a848794f8e11f401ba0b71c49fbd26fb40b71788b132"},
-    {file = "numpy-1.19.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:56ef7f56470c24bb67fb43dae442e946a6ce172f97c69f8d067ff8550cf782ff"},
-    {file = "numpy-1.19.1-cp36-cp36m-win32.whl", hash = "sha256:aaf42a04b472d12515debc621c31cf16c215e332242e7a9f56403d814c744624"},
-    {file = "numpy-1.19.1-cp36-cp36m-win_amd64.whl", hash = "sha256:082f8d4dd69b6b688f64f509b91d482362124986d98dc7dc5f5e9f9b9c3bb983"},
-    {file = "numpy-1.19.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:e4f6d3c53911a9d103d8ec9518190e52a8b945bab021745af4939cfc7c0d4a9e"},
-    {file = "numpy-1.19.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:5b6885c12784a27e957294b60f97e8b5b4174c7504665333c5e94fbf41ae5d6a"},
-    {file = "numpy-1.19.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:1bc0145999e8cb8aed9d4e65dd8b139adf1919e521177f198529687dbf613065"},
-    {file = "numpy-1.19.1-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:5a936fd51049541d86ccdeef2833cc89a18e4d3808fe58a8abeb802665c5af93"},
-    {file = "numpy-1.19.1-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:ef71a1d4fd4858596ae80ad1ec76404ad29701f8ca7cdcebc50300178db14dfc"},
-    {file = "numpy-1.19.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:b9792b0ac0130b277536ab8944e7b754c69560dac0415dd4b2dbd16b902c8954"},
-    {file = "numpy-1.19.1-cp37-cp37m-win32.whl", hash = "sha256:b12e639378c741add21fbffd16ba5ad25c0a1a17cf2b6fe4288feeb65144f35b"},
-    {file = "numpy-1.19.1-cp37-cp37m-win_amd64.whl", hash = "sha256:8343bf67c72e09cfabfab55ad4a43ce3f6bf6e6ced7acf70f45ded9ebb425055"},
-    {file = "numpy-1.19.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:e45f8e981a0ab47103181773cc0a54e650b2aef8c7b6cd07405d0fa8d869444a"},
-    {file = "numpy-1.19.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:667c07063940e934287993366ad5f56766bc009017b4a0fe91dbd07960d0aba7"},
-    {file = "numpy-1.19.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:480fdd4dbda4dd6b638d3863da3be82873bba6d32d1fc12ea1b8486ac7b8d129"},
-    {file = "numpy-1.19.1-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:935c27ae2760c21cd7354402546f6be21d3d0c806fffe967f745d5f2de5005a7"},
-    {file = "numpy-1.19.1-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:309cbcfaa103fc9a33ec16d2d62569d541b79f828c382556ff072442226d1968"},
-    {file = "numpy-1.19.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:7ed448ff4eaffeb01094959b19cbaf998ecdee9ef9932381420d514e446601cd"},
-    {file = "numpy-1.19.1-cp38-cp38-win32.whl", hash = "sha256:de8b4a9b56255797cbddb93281ed92acbc510fb7b15df3f01bd28f46ebc4edae"},
-    {file = "numpy-1.19.1-cp38-cp38-win_amd64.whl", hash = "sha256:92feb989b47f83ebef246adabc7ff3b9a59ac30601c3f6819f8913458610bdcc"},
-    {file = "numpy-1.19.1-pp36-pypy36_pp73-manylinux2010_x86_64.whl", hash = "sha256:e1b1dc0372f530f26a03578ac75d5e51b3868b9b76cd2facba4c9ee0eb252ab1"},
-    {file = "numpy-1.19.1.zip", hash = "sha256:b8456987b637232602ceb4d663cb34106f7eb780e247d51a260b84760fd8f491"},
+    {file = "numpy-1.19.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:b594f76771bc7fc8a044c5ba303427ee67c17a09b36e1fa32bde82f5c419d17a"},
+    {file = "numpy-1.19.2-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:e6ddbdc5113628f15de7e4911c02aed74a4ccff531842c583e5032f6e5a179bd"},
+    {file = "numpy-1.19.2-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:3733640466733441295b0d6d3dcbf8e1ffa7e897d4d82903169529fd3386919a"},
+    {file = "numpy-1.19.2-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:4339741994c775396e1a274dba3609c69ab0f16056c1077f18979bec2a2c2e6e"},
+    {file = "numpy-1.19.2-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:7c6646314291d8f5ea900a7ea9c4261f834b5b62159ba2abe3836f4fa6705526"},
+    {file = "numpy-1.19.2-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:7118f0a9f2f617f921ec7d278d981244ba83c85eea197be7c5a4f84af80a9c3c"},
+    {file = "numpy-1.19.2-cp36-cp36m-win32.whl", hash = "sha256:9a3001248b9231ed73894c773142658bab914645261275f675d86c290c37f66d"},
+    {file = "numpy-1.19.2-cp36-cp36m-win_amd64.whl", hash = "sha256:967c92435f0b3ba37a4257c48b8715b76741410467e2bdb1097e8391fccfae15"},
+    {file = "numpy-1.19.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:d526fa58ae4aead839161535d59ea9565863bb0b0bdb3cc63214613fb16aced4"},
+    {file = "numpy-1.19.2-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:eb25c381d168daf351147713f49c626030dcff7a393d5caa62515d415a6071d8"},
+    {file = "numpy-1.19.2-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:62139af94728d22350a571b7c82795b9d59be77fc162414ada6c8b6a10ef5d02"},
+    {file = "numpy-1.19.2-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:0c66da1d202c52051625e55a249da35b31f65a81cb56e4c69af0dfb8fb0125bf"},
+    {file = "numpy-1.19.2-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:2117536e968abb7357d34d754e3733b0d7113d4c9f1d921f21a3d96dec5ff716"},
+    {file = "numpy-1.19.2-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:54045b198aebf41bf6bf4088012777c1d11703bf74461d70cd350c0af2182e45"},
+    {file = "numpy-1.19.2-cp37-cp37m-win32.whl", hash = "sha256:aba1d5daf1144b956bc87ffb87966791f5e9f3e1f6fab3d7f581db1f5b598f7a"},
+    {file = "numpy-1.19.2-cp37-cp37m-win_amd64.whl", hash = "sha256:addaa551b298052c16885fc70408d3848d4e2e7352de4e7a1e13e691abc734c1"},
+    {file = "numpy-1.19.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:58d66a6b3b55178a1f8a5fe98df26ace76260a70de694d99577ddeab7eaa9a9d"},
+    {file = "numpy-1.19.2-cp38-cp38-manylinux1_i686.whl", hash = "sha256:59f3d687faea7a4f7f93bd9665e5b102f32f3fa28514f15b126f099b7997203d"},
+    {file = "numpy-1.19.2-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:cebd4f4e64cfe87f2039e4725781f6326a61f095bc77b3716502bed812b385a9"},
+    {file = "numpy-1.19.2-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:c35a01777f81e7333bcf276b605f39c872e28295441c265cd0c860f4b40148c1"},
+    {file = "numpy-1.19.2-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:d7ac33585e1f09e7345aa902c281bd777fdb792432d27fca857f39b70e5dd31c"},
+    {file = "numpy-1.19.2-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:04c7d4ebc5ff93d9822075ddb1751ff392a4375e5885299445fcebf877f179d5"},
+    {file = "numpy-1.19.2-cp38-cp38-win32.whl", hash = "sha256:51ee93e1fac3fe08ef54ff1c7f329db64d8a9c5557e6c8e908be9497ac76374b"},
+    {file = "numpy-1.19.2-cp38-cp38-win_amd64.whl", hash = "sha256:1669ec8e42f169ff715a904c9b2105b6640f3f2a4c4c2cb4920ae8b2785dac65"},
+    {file = "numpy-1.19.2-pp36-pypy36_pp73-manylinux2010_x86_64.whl", hash = "sha256:0bfd85053d1e9f60234f28f63d4a5147ada7f432943c113a11afcf3e65d9d4c8"},
+    {file = "numpy-1.19.2.zip", hash = "sha256:0d310730e1e793527065ad7dde736197b705d0e4c9999775f212b03c44a8484c"},
 ]
 opt-einsum = [
     {file = "opt_einsum-3.3.0-py3-none-any.whl", hash = "sha256:2455e59e3947d3c275477df7f5205b30635e266fe6dc300e3d9f9646bfcea147"},
@@ -910,22 +911,22 @@ packaging = [
     {file = "packaging-20.4.tar.gz", hash = "sha256:4357f74f47b9c12db93624a82154e9b120fa8293699949152b22065d556079f8"},
 ]
 pandas = [
-    {file = "pandas-1.1.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:8c9ec12c480c4d915e23ee9c8a2d8eba8509986f35f307771045c1294a2e5b73"},
-    {file = "pandas-1.1.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:e4b6c98f45695799990da328e6fd7d6187be32752ed64c2f22326ad66762d179"},
-    {file = "pandas-1.1.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:16ae070c47474008769fc443ac765ffd88c3506b4a82966e7a605592978896f9"},
-    {file = "pandas-1.1.1-cp36-cp36m-win32.whl", hash = "sha256:88930c74f69e97b17703600233c0eaf1f4f4dd10c14633d522724c5c1b963ec4"},
-    {file = "pandas-1.1.1-cp36-cp36m-win_amd64.whl", hash = "sha256:fe6f1623376b616e03d51f0dd95afd862cf9a33c18cf55ce0ed4bbe1c4444391"},
-    {file = "pandas-1.1.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:a81c4bf9c59010aa3efddbb6b9fc84a9b76dc0b4da2c2c2d50f06a9ef6ac0004"},
-    {file = "pandas-1.1.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:1acc2bd7fc95e5408a4456897c2c2a1ae7c6acefe108d90479ab6d98d34fcc3d"},
-    {file = "pandas-1.1.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:84c101d0f7bbf0d9f1be9a2f29f6fcc12415442558d067164e50a56edfb732b4"},
-    {file = "pandas-1.1.1-cp37-cp37m-win32.whl", hash = "sha256:391db82ebeb886143b96b9c6c6166686c9a272d00020e4e39ad63b792542d9e2"},
-    {file = "pandas-1.1.1-cp37-cp37m-win_amd64.whl", hash = "sha256:0366150fe8ee37ef89a45d3093e05026b5f895e42bbce3902ce3b6427f1b8471"},
-    {file = "pandas-1.1.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:d9644ac996149b2a51325d48d77e25c911e01aa6d39dc1b64be679cd71f683ec"},
-    {file = "pandas-1.1.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:41675323d4fcdd15abde068607cad150dfe17f7d32290ee128e5fea98442bd09"},
-    {file = "pandas-1.1.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:0246c67cbaaaac8d25fed8d4cf2d8897bd858f0e540e8528a75281cee9ac516d"},
-    {file = "pandas-1.1.1-cp38-cp38-win32.whl", hash = "sha256:01b1e536eb960822c5e6b58357cad8c4b492a336f4a5630bf0b598566462a578"},
-    {file = "pandas-1.1.1-cp38-cp38-win_amd64.whl", hash = "sha256:57c5f6be49259cde8e6f71c2bf240a26b071569cabc04c751358495d09419e56"},
-    {file = "pandas-1.1.1.tar.gz", hash = "sha256:53328284a7bb046e2e885fd1b8c078bd896d7fc4575b915d4936f54984a2ba67"},
+    {file = "pandas-1.1.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:eb0ac2fd04428f18b547716f70c699a7cc9c65a6947ed8c7e688d96eb91e3db8"},
+    {file = "pandas-1.1.2-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:02ec9f5f0b7df7227931a884569ef0b6d32d76789c84bcac1a719dafd1f912e8"},
+    {file = "pandas-1.1.2-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:1edf6c254d2d138188e9987159978ee70e23362fe9197f3f100844a197f7e1e4"},
+    {file = "pandas-1.1.2-cp36-cp36m-win32.whl", hash = "sha256:b821f239514a9ce46dd1cd6c9298a03ed58d0235d414ea264aacc1b14916bbe4"},
+    {file = "pandas-1.1.2-cp36-cp36m-win_amd64.whl", hash = "sha256:ab6ea0f3116f408a8a59cd50158bfd19d2a024f4e221f14ab1bcd2da4f0c6fdf"},
+    {file = "pandas-1.1.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:474fa53e3b2f3a543cbca81f7457bd1f44e7eb1be7171067636307e21b624e9c"},
+    {file = "pandas-1.1.2-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:9e135ce9929cd0f0ba24f0545936af17ba935f844d4c3a2b979354a73c9440e0"},
+    {file = "pandas-1.1.2-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:188cdfbf8399bc144fa95040536b5ce3429d2eda6c9c8b238c987af7df9f128c"},
+    {file = "pandas-1.1.2-cp37-cp37m-win32.whl", hash = "sha256:08783a33989a6747317766b75be30a594a9764b9f145bb4bcc06e337930d9807"},
+    {file = "pandas-1.1.2-cp37-cp37m-win_amd64.whl", hash = "sha256:f7008ec22b92d771b145150978d930a28fab8da3a10131b01bbf39574acdad0b"},
+    {file = "pandas-1.1.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:59df9f0276aa4854d8bff28c5e5aeb74d9c6bb4d9f55d272b7124a7df40e47d0"},
+    {file = "pandas-1.1.2-cp38-cp38-manylinux1_i686.whl", hash = "sha256:eeb64c5b3d4f2ea072ca8afdeb2b946cd681a863382ca79734f1b520b8d2fa26"},
+    {file = "pandas-1.1.2-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:c9235b37489168ed6b173551c816b50aa89f03c24a8549a8b4d47d8dc79bfb1e"},
+    {file = "pandas-1.1.2-cp38-cp38-win32.whl", hash = "sha256:0936991228241db937e87f82ec552a33888dd04a2e0d5a2fa3c689f92fab09e0"},
+    {file = "pandas-1.1.2-cp38-cp38-win_amd64.whl", hash = "sha256:026d764d0b86ee53183aa4c0b90774b6146123eeada4e24946d7d24290777be1"},
+    {file = "pandas-1.1.2.tar.gz", hash = "sha256:b64ffd87a2cfd31b40acd4b92cb72ea9a52a48165aec4c140e78fd69c45d1444"},
 ]
 parso = [
     {file = "parso-0.7.1-py2.py3-none-any.whl", hash = "sha256:97218d9159b2520ff45eb78028ba8b50d2bc61dcc062a9682666f2dc4bd331ea"},
@@ -944,8 +945,8 @@ pickleshare = [
     {file = "pickleshare-0.7.5.tar.gz", hash = "sha256:87683d47965c1da65cdacaf31c8441d12b8044cdec9aca500cd78fc2c683afca"},
 ]
 plotly = [
-    {file = "plotly-4.9.0-py2.py3-none-any.whl", hash = "sha256:7c7b613af8def74f48b1298f08a49086bb9792104119feb4a137f737533021e1"},
-    {file = "plotly-4.9.0.tar.gz", hash = "sha256:257f530ffd73754bd008454826905657b329053364597479bb9774437a396837"},
+    {file = "plotly-4.10.0-py2.py3-none-any.whl", hash = "sha256:752f0803588b8d895d604c58fa55119ad104f3fbdd5eb5f7d11a3079680c31c0"},
+    {file = "plotly-4.10.0.tar.gz", hash = "sha256:aa1602346ffa17895687fc48ae58611f014ed7a5da4b07e79c2ca99d6d4dca31"},
 ]
 pluggy = [
     {file = "pluggy-0.13.1-py2.py3-none-any.whl", hash = "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"},
@@ -976,8 +977,8 @@ pyflakes = [
     {file = "pyflakes-2.2.0.tar.gz", hash = "sha256:35b2d75ee967ea93b55750aa9edbbf72813e06a66ba54438df2cfac9e3c27fc8"},
 ]
 pygments = [
-    {file = "Pygments-2.6.1-py3-none-any.whl", hash = "sha256:ff7a40b4860b727ab48fad6360eb351cc1b33cbf9b15a0f689ca5353e9463324"},
-    {file = "Pygments-2.6.1.tar.gz", hash = "sha256:647344a061c249a3b74e230c739f434d7ea4d8b1d5f3721bc0f3558049b38f44"},
+    {file = "Pygments-2.7.1-py3-none-any.whl", hash = "sha256:307543fe65c0947b126e83dd5a61bd8acbd84abec11f43caebaf5534cbc17998"},
+    {file = "Pygments-2.7.1.tar.gz", hash = "sha256:926c3f319eda178d1bd90851e4317e6d8cdb5e292a3386aac9bd75eca29cf9c7"},
 ]
 pyparsing = [
     {file = "pyparsing-2.4.7-py2.py3-none-any.whl", hash = "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"},
@@ -1061,8 +1062,8 @@ toml = [
     {file = "toml-0.10.1.tar.gz", hash = "sha256:926b612be1e5ce0634a2ca03470f95169cf16f939018233a670519cb4ac58b0f"},
 ]
 tqdm = [
-    {file = "tqdm-4.48.2-py2.py3-none-any.whl", hash = "sha256:1a336d2b829be50e46b84668691e0a2719f26c97c62846298dd5ae2937e4d5cf"},
-    {file = "tqdm-4.48.2.tar.gz", hash = "sha256:564d632ea2b9cb52979f7956e093e831c28d441c11751682f84c86fc46e4fd21"},
+    {file = "tqdm-4.49.0-py2.py3-none-any.whl", hash = "sha256:8f3c5815e3b5e20bc40463fa6b42a352178859692a68ffaa469706e6d38342a5"},
+    {file = "tqdm-4.49.0.tar.gz", hash = "sha256:faf9c671bd3fad5ebaeee366949d969dca2b2be32c872a7092a1e1a9048d105b"},
 ]
 traitlets = [
     {file = "traitlets-4.3.3-py2.py3-none-any.whl", hash = "sha256:70b4c6a1d9019d7b4f6846832288f86998aa3b9207c6821f3578a6a6a467fe44"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ pre-commit = "^2.7.1"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.4.1"
-black = "^20.8b1"
+black = "20.8b1"
 pre-commit = "^2.2.0"
 flake8 = "^3.8.3"
 ipython = "^7.15.0"

--- a/tests/epi/test_seir.py
+++ b/tests/epi/test_seir.py
@@ -1,0 +1,27 @@
+import jax
+import jax.numpy as jnp
+import networkx as nx
+from netprocess import epi, network_process
+
+
+def test_sir_model():
+    N = 30
+    g = nx.random_graphs.barabasi_albert_graph(N, 3, seed=42)
+    np = network_process.NetworkProcess([epi.SIRUpdateOp()])
+
+    s = np.new_state(g, params_pytree={"edge_beta": 0.05, "gamma": 0.1}, seed=43)
+
+    # Few passes without any infections
+    s = np.run(s, steps=2)
+    print(np.trace_log())
+    assert sum(s.nodes_pytree["compartment"]) == 0
+
+    # Infect a single high-degree node
+    s.nodes_pytree["compartment"] = jax.ops.index_update(
+        s.nodes_pytree["compartment"], 0, 1
+    )
+
+    # Infection spread
+    for i in range(5):
+        s = np.run(s, steps=5)
+        print(s.nodes_pytree["compartment"])

--- a/tests/network_process/test_process.py
+++ b/tests/network_process/test_process.py
@@ -71,6 +71,12 @@ def test_custom_process():
                 "_nope": 0,
             }
 
+        def update_params(self, rng_key, state, orig_state):
+            return {"_a": jnp.sum(state.nodes_pytree["indeg"])}
+
+        def create_record(self, rng_key, state, orig_state):
+            return {"a_rec": state.params_pytree["_a"] * state.edges_pytree["aa"][0]}
+
     np = network_process.NetworkProcess([TestOp()])
     sb0 = _new_state(np)
     sb1 = np.run(sb0, steps=1)
@@ -83,6 +89,7 @@ def test_custom_process():
     assert (sb1.nodes_pytree["y"] == jnp.array([100.1, 287.2, 100.3, 227.4])).all()
     assert (sb1.edges_pytree["stat"] == sb1.edges_pytree["stat"]).all()
     assert (sb1.edges_pytree["aa"] == jnp.array([1.1, 2.3, 3.3, 4.1, 5.2])).all()
+    assert (sb1.all_records()["a_rec"] == jnp.array([5.5])).all()
     # Check underscored are ommited
     assert "_nope" not in sb1.nodes_pytree
     assert "_nope" not in sb1.edges_pytree

--- a/tests/test_jax_utils.py
+++ b/tests/test_jax_utils.py
@@ -8,7 +8,7 @@ from netprocess import jax_utils
 def test_jax_random_choice_range():
     """Ensure that random.choice normalizes the probabilities."""
     k = jax.random.PRNGKey(42)
-    s = jax.random.choice(k, 2, (1000,), p=[1000.0, 2000.0])
+    s = jax.random.choice(k, 2, (1000,), p=jnp.array([1000.0, 2000.0]))
     assert sum(s) < 900
     assert sum(s) > 300
 


### PR DESCRIPTION
The messages passed via edges are now unified: both edge and node ops simply produce new pytree items, either updates or `_temporary` values. Node-updates, edge-updates, parameter-updates and record generator can see all of those generated.

Separate param-updating and record-generating operations. All operations now return just one dict Pytree.


Added listing generated and read items for op debugging.