### PR TITLE
Simplify ProcessState

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -55,4 +55,4 @@ jobs:
       - name: Install dependencies
         run: poetry install
       - name: Test
-        run: poetry run pytest
+        run: poetry run pytest -vv

--- a/netprocess/epidemics/compartmental.py
+++ b/netprocess/epidemics/compartmental.py
@@ -6,7 +6,7 @@ import jax.numpy as jnp
 from netprocess.utils.types import PytreeDict
 
 from ..operations import EdgeUpdateData, NodeUpdateData, OperationBase
-from ..process import ProcessStateData
+from ..process import ProcessState
 from ..utils import KeyOrValue, KeyOrValueT, PytreeDict
 from ..utils.jax_utils import cond
 
@@ -106,7 +106,7 @@ class PoissonCompartmentalUpdateOp(OperationBase):
         else:
             raise TypeError
 
-    def prepare_state_data(self, state: ProcessStateData):
+    def prepare_state_data(self, state: ProcessState):
         """
         Prepare the state for running the process.
 

--- a/netprocess/games/games.py
+++ b/netprocess/games/games.py
@@ -4,7 +4,7 @@ import jax
 import jax.numpy as jnp
 
 from ..operations import EdgeUpdateData, NodeUpdateData, OperationBase
-from ..process import ProcessStateData
+from ..process import ProcessState
 from ..utils import KeyOrValue, KeyOrValueT, PropTree
 from .policies import PlayerPolicyBase
 
@@ -79,7 +79,7 @@ class PureStrategyGame(OperationBase):
                 player == 0, lambda _: p[a1, a2], lambda _: p[a2, a1], None
             )
 
-    def prepare_state_data(self, state: ProcessStateData):
+    def prepare_state_data(self, state: ProcessState):
         """
         Prepare the state for running the process.
 

--- a/netprocess/games/policies.py
+++ b/netprocess/games/policies.py
@@ -1,6 +1,6 @@
 import jax.numpy as jnp
 
-from ..process import ProcessStateData
+from ..process import ProcessState
 from ..utils import KeyOrValue, KeyOrValueT
 from ..operations import NodeUpdateData
 
@@ -13,7 +13,7 @@ class PlayerPolicyBase:
     ) -> jnp.ndarray:
         raise NotImplemented
 
-    def prepare_state_data(self, state: ProcessStateData):
+    def prepare_state_data(self, state: ProcessState):
         pass
 
 
@@ -21,7 +21,7 @@ class SoftmaxPolicy(PlayerPolicyBase):
     def __init__(self, beta: KeyOrValueT):
         self.beta = KeyOrValue(beta)
 
-    def prepare_state_data(self, state: ProcessStateData):
+    def prepare_state_data(self, state: ProcessState):
         self.beta.ensure_in(state)
 
     def compute_policy(
@@ -42,7 +42,7 @@ class EpsilonErrorPolicy(PlayerPolicyBase):
     def __init__(self, epsilon: KeyOrValueT = 0.0):
         self.epsilon = KeyOrValue(epsilon)
 
-    def prepare_state_data(self, state: ProcessStateData):
+    def prepare_state_data(self, state: ProcessState):
         self.epsilon.ensure_in(state)
 
     def compute_policy(

--- a/netprocess/operations/common.py
+++ b/netprocess/operations/common.py
@@ -1,4 +1,4 @@
-from ..process.state import ProcessStateData
+from ..process.state import ProcessState
 from ..utils import KeyOrValue, KeyOrValueT
 from .base import EdgeUpdateData, NodeUpdateData, OperationBase, ParamUpdateData
 
@@ -50,7 +50,7 @@ class IncrementParam(OperationBase):
         self.value = KeyOrValue(value_key, default=default, dtype=dtype)
         self.increment = KeyOrValue(increment, dtype=dtype)
 
-    def prepare_state_data(self, data: ProcessStateData):
+    def prepare_state_data(self, data: ProcessState):
         self.value.ensure_in(data)
         self.increment.ensure_in(data)
 

--- a/netprocess/process/__init__.py
+++ b/netprocess/process/__init__.py
@@ -1,2 +1,3 @@
 from .process import NetworkProcess
-from .state import ProcessState, ProcessStateData
+from .state import ProcessState
+from .records import ProcessRecords

--- a/netprocess/process/process.py
+++ b/netprocess/process/process.py
@@ -36,13 +36,19 @@ class NetworkProcess:
         return f"<{self.__class__.__name__} {self.operations}>"
 
     def run(self, state: ProcessState, steps=1, jit=True) -> ProcessState:
+        state = state.copy()
+        net, rec = state._network, state._records
+        state._network, state._records = None, None
+
         steps_array = jnp.arange(state.step, state.step + steps, dtype=jnp.int32)
         if jit:
             state, records = self._run_jit(state, steps_array, tracing=True, jit=True)
         else:
             state, records = self._run(state, steps_array, tracing=False, jit=False)
+
+        state._network, state._records = net, rec
         if len(records) > 0:
-            state._records.add_record(records)
+            state.records.add_record(records)
         return state
 
     def trace_log(self):

--- a/netprocess/process/records.py
+++ b/netprocess/process/records.py
@@ -75,7 +75,6 @@ class ProcessRecords:
         m = (self.stride - self.steps) % self.stride
         if m < l:
             strided = jax.tree_util.tree_map(lambda a: a[m :: self.stride], records)
-            print(strided)
             self.records += self._chunk_len(strided)
             self.chunks.append(strided)
         self.steps += l

--- a/netprocess/process/records.py
+++ b/netprocess/process/records.py
@@ -64,15 +64,21 @@ class ProcessRecords:
         return ls[0].shape[0]
 
     def add_record(self, records: Pytree):
+        # Skip records without leaves
+        if len(jax.tree_util.tree_leaves(records)) == 0:
+            return
         # number of new records
         l = self._chunk_len(records)
-        self.steps += l
+        if l == 0:
+            return
         # first new record to take
-        m = (self.stride - (self.steps % self.stride)) % self.stride
+        m = (self.stride - self.steps) % self.stride
         if m < l:
             strided = jax.tree_util.tree_map(lambda a: a[m :: self.stride], records)
+            print(strided)
             self.records += self._chunk_len(strided)
             self.chunks.append(strided)
+        self.steps += l
 
     def block_on_all(self):
         """

--- a/netprocess/process/records.py
+++ b/netprocess/process/records.py
@@ -1,0 +1,83 @@
+import jax
+
+from ..utils import jax_utils, Pytree
+
+
+class ProcessRecords:
+    """
+    A class holding a sequence of records of one process state.
+
+    Records are split into several chunks that are joined on-demand into one final chunk.
+    Every chunk is a Pytree (resp. PropTree), where every array has a new leading dimension for
+    the sequence in history.
+
+    Optionally, only chunks divisible by `stride` are kept in history (they are still computed
+    in-process and passed to this object, though).
+    """
+
+    def __init__(self, stride: int = 1) -> None:
+        self.chunks = []
+        self.stride = stride
+        # Number of stride-1 records (=steps) we have seen
+        self.steps = 0
+        # Number of records kept, also the len
+        self.records = 0
+
+    def __len__(self):
+        return self.records
+
+    def copy(self):
+        """
+        Creates a copy, sharing all the pytrees with the original (assumes none are modified later).
+        """
+        s = ProcessRecords(self.stride)
+        s.chunks = list(self.chunks)
+        s.steps = self.steps
+        s.records = self.records
+        return s
+
+    def last_record(self):
+        """
+        Return pytree of the last record (without the leading record axis)
+        """
+        if len(self.chunks) == 0:
+            raise ValueError(f"No records in {self!r}")
+        return jax.tree_util.tree_map(lambda a: a[-1], self.chunks[-1])
+
+    def all_records(self):
+        """
+        Return the concatenated records as a pytree.
+
+        Fails if no records were recorded so far.
+        """
+        if len(self.chunks) == 0:
+            raise ValueError(f"No records in {self!r}")
+        merged = jax_utils.concatenate_pytrees(self.chunks)
+        assert self._chunk_len(merged) == self.records
+        return merged
+
+    @classmethod
+    def _chunk_len(_cls, chunk: Pytree) -> int:
+        ls = jax.tree_util.tree_leaves(chunk)
+        if not ls:
+            raise ValueError(f"No leaves in Pytree, can't measure chunk length")
+        return ls[0].shape[0]
+
+    def add_record(self, records: Pytree):
+        # number of new records
+        l = self._chunk_len(records)
+        self.steps += l
+        # first new record to take
+        m = (self.stride - (self.steps % self.stride)) % self.stride
+        if m < l:
+            strided = jax.tree_util.tree_map(lambda a: a[m :: self.stride], records)
+            self.records += self._chunk_len(strided)
+            self.chunks.append(strided)
+
+    def block_on_all(self):
+        """
+        Block until all arrays are actually computed (does not copy them to CPU).
+        """
+        if len(self.chunks) > 0:
+            for v in jax.tree_util.tree_leaves(self.chunks[-1]):
+                v.block_until_ready()

--- a/netprocess/process/tracing.py
+++ b/netprocess/process/tracing.py
@@ -59,6 +59,7 @@ class TracingPropTreeWrapper(PropTree):
 
     @classmethod
     def tree_unflatten(cls, aux_data, children):
+        assert cls == TracingPropTreeWrapper
         a, c, _target, _prefix = aux_data
         pt = c.tree_unflatten(a, children)
         return cls(pt, _target=_target, _prefix=_prefix)

--- a/netprocess/utils/jax_utils.py
+++ b/netprocess/utils/jax_utils.py
@@ -74,9 +74,7 @@ def concatenate_pytrees(
     By default checks that the treedefs actually match
     (otherwise only leaf count and order matters).
     """
-    arrays, treedefs = jax.tree_util.unzip2(
-        jax.tree_util.tree_flatten(pt) for pt in pytrees
-    )
+    arrays, treedefs = jax.util.unzip2(jax.tree_util.tree_flatten(pt) for pt in pytrees)
     if check_treedefs:
         for td in treedefs[1:]:
             if td != treedefs[0]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "netprocess"
-version = "0.4.0"
+version = "0.4.1"
 description = "Framework for processes on complex networks: epidemis, game theory, percolation, Ising models. Built on JAX for speed and differentiability."
 authors = ["Tomas Gavenciak <gavento@gmail.com>"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "netprocess"
-version = "0.3.0"
+version = "0.4.0"
 description = "Framework for processes on complex networks: epidemis, game theory, percolation, Ising models. Built on JAX for speed and differentiability."
 authors = ["Tomas Gavenciak <gavento@gmail.com>"]
 

--- a/tests/epidemics/test_seir.py
+++ b/tests/epidemics/test_seir.py
@@ -53,7 +53,7 @@ def test_sir_model():
     assert sum(s.node["compartment"] == 0) in range(2, 5)
     assert sum(s.node["compartment"] == 1) in range(3, 7)
     assert sum(s.node["compartment"] == 2) in range(1, 6)
-    assert abs(s.data["t"] - 8.0) < 1e-3
+    assert abs(s["t"] - 8.0) < 1e-3
     assert np._traced == 1  ## Not essential, testing tracing-once property
 
 

--- a/tests/games/test_games.py
+++ b/tests/games/test_games.py
@@ -62,7 +62,7 @@ def test_pure_strategy_game():
     s = np.new_state(net, seed=43, props={"beta": 1.0})
     s = np.run(s, steps=10, jit=True)
     assert sum(s.node["action"]) > 0.9 * N
-    s.data["beta"] = 0.05
+    s["beta"] = 0.05
     s = np.run(s, steps=10, jit=True)
     print(s.node["action"])
     assert sum(s.node["action"]) < 0.8 * N

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -7,11 +7,10 @@ def test_time_advancing_op():
 
     n0 = Network.from_graph(nx.complete_graph(4))
     sa0 = np.new_state(n0, seed=32, props={"delta_t": 0.1})
-    print(sa0.data)
     sa1 = np.run(sa0, steps=4, jit=False)
-    assert abs(sa1.data["t"] - 0.4) < 1e-6
+    assert abs(sa1["t"] - 0.4) < 1e-6
 
     np = NetworkProcess([operations.IncrementParam("t", 1.0, default=0.0)])
     sb0 = np.new_state(n0, seed=42)
     sb1 = np.run(sb0, steps=5, jit=False)
-    assert abs(sb1.data["t"] - 5.0) < 1e-6
+    assert abs(sb1["t"] - 5.0) < 1e-6

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -13,6 +13,8 @@ from netprocess.operations import (
 from netprocess.process import ProcessRecords, ProcessState
 from networkx.generators import directed
 
+from netprocess.utils.prop_tree import PropTree
+
 
 def _new_state(process):
     net = Network.from_edges(
@@ -68,6 +70,35 @@ def test_nop_process():
     sb1["step"] = 0
     sb1["prng_key"] = sb0.prng_key
     assert sb0.data_eq(sb1)
+
+
+def test_records():
+    pr = ProcessRecords(stride=1)
+    pr.add_record(PropTree(a=[1, 2, 3]))
+    assert len(pr) == 3
+    assert pr.steps == 3
+    pr.add_record(PropTree(a=[4, 5]))
+    pr.add_record(PropTree(a=[]))
+    assert len(pr) == 5
+    assert pr.last_record()["a"] == 5
+    pra = pr.all_records()
+    assert isinstance(pra, PropTree)
+    assert pra.data_eq(PropTree(a=[1, 2, 3, 4, 5]))
+
+    print("second")
+    pr = ProcessRecords(stride=3)
+    pr.add_record(PropTree(a=[0, 1, 2, 3, 4]))
+    assert len(pr) == 2
+    assert pr.steps == 5
+    pr.add_record(PropTree(a=[]))
+    pr.add_record(PropTree(a=[5]))
+    pr.add_record(PropTree(a=[6]))
+    pr.add_record(PropTree(a=[7, 8, 9]))
+    pr.add_record(PropTree(a=[10]))
+    pr.add_record(PropTree(a=[11, 12, 13]))
+    pra = pr.all_records()
+    print(pra)
+    assert pra.data_eq(PropTree(a=[0, 3, 6, 9, 12]))
 
 
 def test_custom_process():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -68,6 +68,15 @@ def test_prop_tree():
     p2 = jax.tree_util.tree_map(lambda x: x, p)
     assert list(p2.items()) == list(p.items())
 
+    assert p.data_eq(p2)
+    assert not PropTree(a=1, b=2).data_eq(PropTree(a=1))
+    assert not PropTree(a=1).data_eq(PropTree(a=1, b=2))
+    assert PropTree(a={"x": 1}).data_eq(PropTree(a={"x": 1}, b={"c": {}}))
+    assert PropTree(a={"x": True}).data_eq(PT1(a={"x": True}, z={}))
+    assert PropTree(a=1.13).data_eq(PropTree(a=1.13))
+    assert not PropTree(a=1.13).data_eq(PropTree(a=1.13001))
+    assert PropTree(a=1.13).data_eq(PropTree(a=1.13001), eps=0.001)
+
 
 def test_integrality():
     assert not utils.is_integer(1.0)


### PR DESCRIPTION
Removes `ProcessState` and replaces it with `ProcessStateData`

Also fixes some issues with un/flattening `ProcessStateData` and separates out `ProcessRecord` functionality (now copied on state branching!), also adding some tests.